### PR TITLE
Example Config Inst ID

### DIFF
--- a/example_config.json
+++ b/example_config.json
@@ -9,7 +9,7 @@
                 "id": 12345
             },
             "enabled": true,
-            "chords_inst_id": 11111,
+            "chords_inst_id": "11111",
             "variables": [
                 {
                     "rtl_name": "consumption_data",


### PR DESCRIPTION
Fix example config where pychords requires inst_id to be a str.